### PR TITLE
scaleCanvasWithAlgorithm does not apply the correct width

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -65,7 +65,7 @@ scaleImage = scaleImage;var _exif = require('./exif');var _exif2 = _interopRequi
   }
 
   if (canvas.width > maxWidth) {
-    canvas = scaleCanvasWithAlgorithm(canvas, config);
+    canvas = scaleCanvasWithAlgorithm(canvas, Object.assign(config, { outputWidth: maxWidth }));
   }
 
   var imageData = canvas.toDataURL('image/jpeg', config.quality);
@@ -188,7 +188,7 @@ function dataURIToBlob(dataURI) {
 function scaleCanvasWithAlgorithm(canvas, config) {
   var scaledCanvas = document.createElement('canvas');
 
-  var scale = config.maxWidth / canvas.width;
+  var scale = config.outputWidth / canvas.width;
 
   scaledCanvas.width = canvas.width * scale;
   scaledCanvas.height = canvas.height * scale;

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export function scaleImage(img, config, orientation = 1) {
   }
 
   if (canvas.width > maxWidth) {
-    canvas = scaleCanvasWithAlgorithm(canvas, config);
+    canvas = scaleCanvasWithAlgorithm(canvas, Object.assign(config, { outputWidth: maxWidth }));
   }
 
   let imageData = canvas.toDataURL('image/jpeg', config.quality);
@@ -188,7 +188,7 @@ function dataURIToBlob(dataURI) {
 function scaleCanvasWithAlgorithm(canvas, config) {
   var scaledCanvas = document.createElement('canvas');
 
-  var scale = config.maxWidth / canvas.width;
+  var scale = config.outputWidth / canvas.width;
 
   scaledCanvas.width = canvas.width * scale;
   scaledCanvas.height = canvas.height * scale;


### PR DESCRIPTION
scaleCanvasWithAlgorithm should apply the width calcuated by findMaxWidth. Otherwise, the output file will only adopt the maxWidth from config, which will sometimes even enlarge the output dimensions.
For example, in current base, a 1080x1620 image with { maxWidth: 1200, maxHeight: 1200 } config will result in a 1200X1800 image.