### PR TITLE
output dimensions should not increase when original width and height < the max in conig

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -65,7 +65,7 @@ scaleImage = scaleImage;var _exif = require('./exif');var _exif2 = _interopRequi
   }
 
   if (canvas.width > maxWidth) {
-    canvas = scaleCanvasWithAlgorithm(canvas, config);
+    canvas = scaleCanvasWithAlgorithm(canvas, Object.assign(config, { outputWidth: maxWidth }));
   }
 
   var imageData = canvas.toDataURL('image/jpeg', config.quality);
@@ -188,7 +188,7 @@ function dataURIToBlob(dataURI) {
 function scaleCanvasWithAlgorithm(canvas, config) {
   var scaledCanvas = document.createElement('canvas');
 
-  var scale = config.maxWidth / canvas.width;
+  var scale = config.outputWidth / canvas.width;
 
   scaledCanvas.width = canvas.width * scale;
   scaledCanvas.height = canvas.height * scale;

--- a/build/index.js
+++ b/build/index.js
@@ -76,14 +76,14 @@ scaleImage = scaleImage;var _exif = require('./exif');var _exif2 = _interopRequi
 function findMaxWidth(config, canvas) {
   //Let's find the max available width for scaled image
   var ratio = canvas.width / canvas.height;
-  var mWidth = Math.min(config.maxWidth, ratio * config.maxHeight);
+  var mWidth = Math.min(canvas.width, config.maxWidth, ratio * config.maxHeight);
   if (
   config.maxSize > 0 &&
   config.maxSize < canvas.width * canvas.height / 1000)
 
   mWidth = Math.min(
   mWidth,
-  Math.floor(Math.sqrt(config.maxSize * ratio)));
+  Math.floor(config.maxSize * 1000 / canvas.height));
 
   if (!!config.scaleRatio)
   mWidth = Math.min(

--- a/src/index.js
+++ b/src/index.js
@@ -76,14 +76,14 @@ export function scaleImage(img, config, orientation = 1) {
 function findMaxWidth(config, canvas) {
   //Let's find the max available width for scaled image
   var ratio = canvas.width / canvas.height;
-  var mWidth = Math.min(config.maxWidth, ratio * config.maxHeight);
+  var mWidth = Math.min(canvas.width, config.maxWidth, ratio * config.maxHeight);
   if (
     config.maxSize > 0 &&
     config.maxSize < canvas.width * canvas.height / 1000
   )
     mWidth = Math.min(
       mWidth,
-      Math.floor(Math.sqrt(config.maxSize * ratio))
+      Math.floor(config.maxSize * 1000 / canvas.height)
     );
   if (!!config.scaleRatio)
     mWidth = Math.min(

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export function scaleImage(img, config, orientation = 1) {
   }
 
   if (canvas.width > maxWidth) {
-    canvas = scaleCanvasWithAlgorithm(canvas, config);
+    canvas = scaleCanvasWithAlgorithm(canvas, Object.assign(config, { outputWidth: maxWidth }));
   }
 
   let imageData = canvas.toDataURL('image/jpeg', config.quality);
@@ -188,7 +188,7 @@ function dataURIToBlob(dataURI) {
 function scaleCanvasWithAlgorithm(canvas, config) {
   var scaledCanvas = document.createElement('canvas');
 
-  var scale = config.maxWidth / canvas.width;
+  var scale = config.outputWidth / canvas.width;
 
   scaledCanvas.width = canvas.width * scale;
   scaledCanvas.height = canvas.height * scale;


### PR DESCRIPTION
And the maxSize property of config is not documented. But from the code, it seems that it should be the pixel count in thousand. Therefore, when using it to calculate the maxWidth it should be timed 1000, and the call to math square root can be avoided with some changes to the calculation.